### PR TITLE
Subscription management for database. Reset capability.

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -145,6 +145,7 @@ export class AngularFireOfflineDatabase {
     this.subscriptions = [];
     this.listCache = {};
     this.objectCache = {};
+    this.localForage.clear();
   };
   /**
    * Retrives a list if locally stored on the device


### PR DESCRIPTION
- Subscriptions to firebase are tracked in an array to be released when necessary.
- Added public `reset()` method to unsubscribe on all subscriptions and clear the caches. This is especially necessary, on logout, or any other cause for permission change.

**Caution:** The current implementation might cause data loss on reset because the caches will be erased. For developers using this feature on logout, mage sure the user can't log out while offline to prevent data loss. Logout should only be available when online after data is synced.

The changes are backward compatible so no change is necessary for apps that don't need to reset the database.