### PR TITLE
consistent use of promise for AfoListObservable push

### DIFF
--- a/src/database/afo-list-observable.spec.ts
+++ b/src/database/afo-list-observable.spec.ts
@@ -29,9 +29,10 @@ describe('List Observable', () => {
       }
     }};
     let pushPromise;
-    ref.$ref.push = (value, callback) => {
-      callback();
-      return 'key-1';
+    ref.$ref.push = (value) => {
+      let key = 'key-1';
+      pushPromise = Promise.resolve(key);
+      return pushPromise;
     };
     mockLocalForageService = new MockLocalForageService();
     localUpdateService = new LocalUpdateService(mockLocalForageService);
@@ -39,7 +40,8 @@ describe('List Observable', () => {
 
   it('should push', done => {
     listObservable = new AfoListObservable<any>(ref, localUpdateService);
-    listObservable.push('new value').then(() => {
+    listObservable.push('new value').then((key) => {
+      expect(key).toBe('key-1');
       done();
     });
   });

--- a/src/database/afo-list-observable.ts
+++ b/src/database/afo-list-observable.ts
@@ -91,13 +91,10 @@ export class AfoListObservable<T> extends ReplaySubject<T> {
    * - Saves the write locally in case the browser is refreshed before the AngularFire2 promise
    * completes
    */
-  push(value: any) {
-    let resolve;
-    let promise: any = new Promise(r => resolve = r);
-    const key = this.ref.$ref.push(value, () => {
-      resolve();
-    }).key;
-    promise.key = key;
+  push(value: any): firebase.Promise<void> {
+    let promise = this.ref.$ref.push(value);
+    const key = promise.key;
+
     this.emulate('push', value, key);
     OfflineWrite(
       promise,


### PR DESCRIPTION
fixes https://github.com/adriancarriger/angularfire2-offline/issues/27

this is proposition to keep consitent use of firebase API i.e. to always use `then` to chain `Promise` and return `Promise` from `AfoListObservable.push`

as full signature of `firebase.database.Reference.push` is
```typescript
push (value ? : any , onComplete ? : (a : Error | null ) => any ) : firebase.database.ThenableReference
```

probably its worth supporting `onComplete` callback as well